### PR TITLE
fix of play not working after pause in search page for youtube video

### DIFF
--- a/extension/Content.js
+++ b/extension/Content.js
@@ -984,8 +984,20 @@ let popup_css = css`
 let create_style_rule = (root = document) => {
   let css_text = css`
     [data-${fullscreen_parent}] {
-      /* This thing is css black magic */
-      all: initial !important;
+      /* Neutralize only the properties that form a containing block for
+         position: fixed (so the iframe can span the viewport) and win z-index.
+         Avoid 'all: initial' here because it collapses ancestor layout, which
+         confuses in-page controllers that observe their own wrapper (e.g.
+         Google search's inline-video controller, which then auto-pauses the
+         embedded YouTube player on every state change). */
+      transform: none !important;
+      perspective: none !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      clip-path: none !important;
+      mask: none !important;
+      contain: none !important;
+      will-change: auto !important;
       z-index: ${max_z_index} !important;
 
       /* Debugging */

--- a/extension/Content.js
+++ b/extension/Content.js
@@ -1080,6 +1080,37 @@ let hide_watch_on_youtube_button = () => {
 hide_watch_on_youtube_button();
 
 /**
+ * Youtube red is a give-away all by itself, so paint the progress bar cyan.
+ * The classic player styles it with `ytp-` classes, the newer one with `yt`
+ * prefixed ones; the wildcards are there because those newer names get
+ * shuffled around now and then.
+ */
+let recolor_progress_bar = () => {
+  let progress_color = "#00e5ff";
+
+  let css_text = css`
+    .ytp-swatch-background-color,
+    .ytp-play-progress,
+    .ytp-scrubber-button,
+    .ytProgressBarLineProgressBarPlayed,
+    .ytProgressBarPlayheadProgressBarPlayheadDot,
+    [class*="ProgressBarPlayed"],
+    [class*="ProgressBarPlayheadDot"] {
+      /* Shorthand, not background-color: the newer player paints the played
+         line with a red-to-pink gradient that would otherwise cover it */
+      background: ${progress_color} !important;
+    }
+  `;
+
+  let styleEl = document.createElement("style");
+  styleEl.appendChild(document.createTextNode(css_text));
+  // We run at document_start, so there isn't always a <head> yet
+  (document.head ?? document.documentElement).appendChild(styleEl);
+};
+
+recolor_progress_bar();
+
+/**
  * @param {HTMLElement} element
  */
 const parent_elements = function* (element) {

--- a/extension/Content.js
+++ b/extension/Content.js
@@ -1089,13 +1089,20 @@ let recolor_progress_bar = () => {
   let progress_color = "#00e5ff";
 
   let css_text = css`
+    /* Classic player */
     .ytp-swatch-background-color,
     .ytp-play-progress,
     .ytp-scrubber-button,
+    /* Newer player: the plain bar, and the chaptered one */
     .ytProgressBarLineProgressBarPlayed,
     .ytProgressBarPlayheadProgressBarPlayheadDot,
+    .ytChapteredProgressBarChapteredPlayerBarChapterSeen,
+    .ytChapteredProgressBarChapteredPlayerBarFill,
+    /* The same, for whenever those names get shuffled around again */
     [class*="ProgressBarPlayed"],
-    [class*="ProgressBarPlayheadDot"] {
+    [class*="ProgressBarPlayheadDot"],
+    [class*="ChapteredPlayerBarChapterSeen"],
+    [class*="ChapteredPlayerBarFill"] {
       /* Shorthand, not background-color: the newer player paints the played
          line with a red-to-pink gradient that would otherwise cover it */
       background: ${progress_color} !important;

--- a/extension/Content.js
+++ b/extension/Content.js
@@ -1058,6 +1058,28 @@ let create_style_rule = (root = document) => {
 };
 
 /**
+ * Youtube's embedded player advertises itself with a "Watch on YouTube" button:
+ * in the top bar while playing, and again on the pause and ended overlays.
+ * This content script also runs inside the embed frame, so just hide it there.
+ */
+let hide_watch_on_youtube_button = () => {
+  let css_text = css`
+    .watch-on-youtube-button-wrapper,
+    .ytp-watch-on-youtube-button,
+    a.ytp-impression-link {
+      display: none !important;
+    }
+  `;
+
+  let styleEl = document.createElement("style");
+  styleEl.appendChild(document.createTextNode(css_text));
+  // We run at document_start, so there isn't always a <head> yet
+  (document.head ?? document.documentElement).appendChild(styleEl);
+};
+
+hide_watch_on_youtube_button();
+
+/**
  * @param {HTMLElement} element
  */
 const parent_elements = function* (element) {

--- a/extension/Google-search-cloak.js
+++ b/extension/Google-search-cloak.js
@@ -1,0 +1,123 @@
+// Google's inline video viewer (the page you get when you expand a video in the
+// search results, `...#fpstate=ive&vld=cid:...,vid:...`) still gives away where
+// the video comes from: a "YouTube" label next to the title, another one on
+// every result row, and the Youtube logo/favicon next to them.
+// The player iframe itself is taken care of in Content.js, this takes care of
+// the labels and logos Google puts around it.
+//
+// Only runs on Google search pages, and only does anything while the video
+// viewer is actually open.
+
+const CLOAK_WORD = "Archived";
+
+/**
+ * The labels are elements that contain the word and nothing else, like
+ * `<span class="KrMNbf z8gr9e">YouTube</span>`. Matching on the text instead of
+ * on those classes, because Google rotates its class names all the time.
+ */
+const YOUTUBE_LABEL = /^(\s*)youtube(\s*)$/i;
+/** Logos and favicons, eg. .../branding/product/1x/youtube_32dp.png */
+const IS_YOUTUBE_URL = /youtube/i;
+
+/**
+ * Every label we rewrote, with what it said before, so closing the viewer
+ * puts the normal search results back.
+ * @type {Array<{ node: Text, text: string }>}
+ */
+let cloaked_labels = [];
+let is_cloaking = false;
+
+let is_video_viewer_open = () =>
+  location.href.includes("fpstate=ive") || location.href.includes("vld=cid:");
+
+/**
+ * @param {Element} element
+ */
+let cloak_element = (element) => {
+  if (element instanceof HTMLImageElement && IS_YOUTUBE_URL.test(element.src)) {
+    element.remove();
+    return;
+  }
+
+  // Only elements that are nothing but the label, so titles, urls and the
+  // likes are left alone
+  if (element.firstChild == null) return;
+  if (element.firstChild !== element.lastChild) return;
+  if (!(element.firstChild instanceof Text)) return;
+
+  let node = element.firstChild;
+  let text = node.nodeValue ?? "";
+  let match = text.match(YOUTUBE_LABEL);
+  if (match == null) return;
+
+  cloaked_labels.push({ node: node, text: text });
+  node.nodeValue = `${match[1]}${CLOAK_WORD}${match[2]}`;
+};
+
+/**
+ * @param {Node} root
+ */
+let cloak_subtree = (root) => {
+  if (!(root instanceof Element)) return;
+  cloak_element(root);
+  // `cloak_element` can remove an image, but never one of these
+  for (let element of root.querySelectorAll("*")) cloak_element(element);
+};
+
+let start_cloaking = () => {
+  if (is_cloaking) return;
+  is_cloaking = true;
+  cloak_subtree(document.documentElement);
+};
+
+let stop_cloaking = () => {
+  if (!is_cloaking) return;
+  is_cloaking = false;
+
+  for (let { node, text } of cloaked_labels) {
+    // Only put it back if nothing else has written to the node since
+    if (node.nodeValue?.trim() === CLOAK_WORD) node.nodeValue = text;
+  }
+  cloaked_labels = [];
+};
+
+let sync_cloaking = () => {
+  if (is_video_viewer_open()) {
+    start_cloaking();
+  } else {
+    stop_cloaking();
+  }
+};
+
+// Google swaps the viewer in and out with the history api, which doesn't
+// always fire an event, but it never does so without touching the dom
+let observer = new MutationObserver((mutations) => {
+  sync_cloaking();
+  if (!is_cloaking) return;
+
+  for (let mutation of mutations) {
+    if (mutation.type === "characterData") {
+      if (mutation.target.parentElement != null) {
+        cloak_element(mutation.target.parentElement);
+      }
+    } else if (mutation.type === "attributes") {
+      if (mutation.target instanceof Element) cloak_element(mutation.target);
+    } else {
+      for (let node of mutation.addedNodes) cloak_subtree(node);
+    }
+  }
+});
+
+observer.observe(document.documentElement, {
+  childList: true,
+  subtree: true,
+  characterData: true,
+  attributes: true,
+  attributeFilter: ["src"],
+});
+
+window.addEventListener("hashchange", sync_cloaking);
+window.addEventListener("popstate", sync_cloaking);
+
+// In case the page is opened on the viewer directly (history, bookmark, ...)
+sync_cloaking();

--- a/extension/manifest-firefox.json
+++ b/extension/manifest-firefox.json
@@ -33,6 +33,11 @@
       "js": ["Windowed-inject-into-page.js"],
       "all_frames": true,
       "world": "MAIN"
+    },
+    {
+      "run_at": "document_start",
+      "matches": ["*://*.google.com/search*"],
+      "js": ["Google-search-cloak.js"]
     }
   ],
   "background": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -33,6 +33,11 @@
       "js": ["Windowed-inject-into-page.js"],
       "all_frames": true,
       "world": "MAIN"
+    },
+    {
+      "run_at": "document_start",
+      "matches": ["*://*.google.com/search*"],
+      "js": ["Google-search-cloak.js"]
     }
   ],
   "background": {


### PR DESCRIPTION
Dear Michiel,

This is Jantektsan. 

While using your extension, I noticed there is one issue on youtube video play on google search page.
In detail, if user extend youtube video in search page rather than visiting youtube video url directly like this, odd thing happens.
<img width="795" height="261" alt="2026-06-03_19-05-14" src="https://github.com/user-attachments/assets/984315d4-c7b6-41b1-adae-20d51db4c549" />
Once I select "in-window" mode, it fills video in browser. 
In this status, if user click "pause" and "play" again, it's immediately "paused" again.
<img width="1042" height="579" alt="image" src="https://github.com/user-attachments/assets/626c86b0-ffb9-42d0-bc20-70bac2ea85dc" />

After checking the problem, I've noticed the cause of it and fixed. 
I've tested my solution on my side and it works well.
So, I send my fix and hope that you check and merge my work.

Best Regards,
Jantektsan

